### PR TITLE
fix http_client_factory argument pass and fixed cncrypto include order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,7 +323,6 @@ if (BUILD_LIBRARY)
       ringct
       ringct_basic
       common
-      cncrypto
       blockchain_db
       blocks
       checkpoints
@@ -331,6 +330,7 @@ if (BUILD_LIBRARY)
       device_trezor
       multisig
       version
+      cncrypto
       randomx
       epee
       hardforks
@@ -419,7 +419,6 @@ if (BUILD_SAMPLE)
       ringct
       ringct_basic
       common
-      cncrypto
       blockchain_db
       blocks
       checkpoints
@@ -427,6 +426,7 @@ if (BUILD_SAMPLE)
       device_trezor
       multisig
       version
+      cncrypto
       randomx
       epee
       hardforks
@@ -491,7 +491,6 @@ if (BUILD_SCRATCHPAD)
       ringct
       ringct_basic
       common
-      cncrypto
       blockchain_db
       blocks
       checkpoints
@@ -499,6 +498,7 @@ if (BUILD_SCRATCHPAD)
       device_trezor
       multisig
       version
+      cncrypto
       randomx
       epee
       hardforks
@@ -563,7 +563,6 @@ if (BUILD_TESTS)
       ringct
       ringct_basic
       common
-      cncrypto
       blockchain_db
       blocks
       checkpoints
@@ -571,6 +570,7 @@ if (BUILD_TESTS)
       device_trezor
       multisig
       version
+      cncrypto
       randomx
       epee
       hardforks
@@ -637,7 +637,6 @@ if (BUILD_LIGHT_TESTS)
       ringct
       ringct_basic
       common
-      cncrypto
       blockchain_db
       blocks
       checkpoints
@@ -645,6 +644,7 @@ if (BUILD_LIGHT_TESTS)
       device_trezor
       multisig
       version
+      cncrypto
       randomx
       epee
       hardforks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(BUILD_LIBRARY ON)
 set(BUILD_SAMPLE OFF)
 set(BUILD_SCRATCHPAD OFF)
 set(BUILD_TESTS OFF)
+set(BUILD_LIGHT_TESTS ON)
 
 ###################
 # monero-project
@@ -272,11 +273,14 @@ set(
     LIBRARY_SRC_FILES
     src/utils/gen_utils.cpp
     src/utils/monero_utils.cpp
+    src/utils/monero_light_client.cpp
+    src/utils/monero_light_model.cpp
     src/daemon/monero_daemon_model.cpp
     src/daemon/monero_daemon.cpp
     src/wallet/monero_wallet_model.cpp
     src/wallet/monero_wallet_keys.cpp
     src/wallet/monero_wallet_full.cpp
+    src/wallet/monero_wallet_light.cpp
 )
 
 if (BUILD_LIBRARY)
@@ -319,6 +323,7 @@ if (BUILD_LIBRARY)
       ringct
       ringct_basic
       common
+      cncrypto
       blockchain_db
       blocks
       checkpoints
@@ -326,7 +331,6 @@ if (BUILD_LIBRARY)
       device_trezor
       multisig
       version
-      cncrypto
       randomx
       epee
       hardforks
@@ -355,8 +359,11 @@ endif()
           DESTINATION include/daemon)
   INSTALL(FILES src/utils/gen_utils.h
           src/utils/monero_utils.h
+          src/utils/monero_light_client.h
+          src/utils/monero_light_model.h
           DESTINATION include/utils)
   INSTALL(FILES src/wallet/monero_wallet_full.h
+          src/wallet/monero_wallet_light.h
           src/wallet/monero_wallet.h
           src/wallet/monero_wallet_keys.h
           src/wallet/monero_wallet_model.h
@@ -412,6 +419,7 @@ if (BUILD_SAMPLE)
       ringct
       ringct_basic
       common
+      cncrypto
       blockchain_db
       blocks
       checkpoints
@@ -419,7 +427,6 @@ if (BUILD_SAMPLE)
       device_trezor
       multisig
       version
-      cncrypto
       randomx
       epee
       hardforks
@@ -484,6 +491,7 @@ if (BUILD_SCRATCHPAD)
       ringct
       ringct_basic
       common
+      cncrypto
       blockchain_db
       blocks
       checkpoints
@@ -491,7 +499,6 @@ if (BUILD_SCRATCHPAD)
       device_trezor
       multisig
       version
-      cncrypto
       randomx
       epee
       hardforks
@@ -556,6 +563,7 @@ if (BUILD_TESTS)
       ringct
       ringct_basic
       common
+      cncrypto
       blockchain_db
       blocks
       checkpoints
@@ -563,7 +571,6 @@ if (BUILD_TESTS)
       device_trezor
       multisig
       version
-      cncrypto
       randomx
       epee
       hardforks
@@ -580,5 +587,79 @@ if (BUILD_TESTS)
   )
   if (NOT WIN32)
     target_link_libraries(monero_tests dl)
+  endif()
+endif()
+
+
+
+########################
+# Build C++ light wallet tests
+########################
+
+if (BUILD_LIGHT_TESTS)
+  set(BUILD_LIGHT_TESTS test/monero_light_tests.cpp)
+  
+  add_executable(monero_light_tests ${LIBRARY_SRC_FILES} ${BUILD_LIGHT_TESTS})
+
+  target_include_directories(monero_light_tests PUBLIC
+      ${CMAKE_CURRENT_SOURCE_DIR}/include
+      src
+      "${MONERO_PROJECT}/contrib/epee/include"
+      "${MONERO_PROJECT}/external/"
+      "${MONERO_PROJECT}/external/easylogging++"
+      "${MONERO_PROJECT}/external/rapidjson/include"
+      "${MONERO_PROJECT_SRC}/"
+      "${MONERO_PROJECT_SRC}/wallet"
+      "${MONERO_PROJECT_SRC}/wallet/api"
+      "${MONERO_PROJECT_SRC}/hardforks"
+      "${MONERO_PROJECT_SRC}/crypto"
+      "${MONERO_PROJECT_SRC}/crypto/crypto_ops_builder/include/"
+      ${Protobuf_INCLUDE_DIR}
+      ${Boost_INCLUDE_DIR}
+      ${OPENSSL_INCLUDE_DIR}
+      external/libsodium/include/sodium
+      external/openssl-sdk/include
+      ${HIDAPI_INCLUDE_DIR}
+      ${UNBOUND_INCLUDE_DIR}
+  )
+  
+  target_link_libraries(monero_light_tests
+      wallet
+      rpc_base
+      net
+      lmdb
+      easylogging
+      cryptonote_core
+      cryptonote_protocol
+      cryptonote_basic
+      cryptonote_format_utils_basic
+      mnemonics
+      ringct
+      ringct_basic
+      common
+      cncrypto
+      blockchain_db
+      blocks
+      checkpoints
+      device
+      device_trezor
+      multisig
+      version
+      randomx
+      epee
+      hardforks
+      ${wallet_crypto}
+      
+      ${UNBOUND_LIBRARIES}
+      ${Boost_LIBRARIES}
+      ${Protobuf_LIBRARY}
+      ${LibUSB_LIBRARIES}
+      ${OPENSSL_LIBRARIES}
+      ${SODIUM_LIBRARY}
+      ${HIDAPI_LIBRARIES}
+      ${EXTRA_LIBRARIES}
+  )
+  if (NOT WIN32)
+    target_link_libraries(monero_light_tests dl)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ set(BUILD_LIBRARY ON)
 set(BUILD_SAMPLE OFF)
 set(BUILD_SCRATCHPAD OFF)
 set(BUILD_TESTS OFF)
-set(BUILD_LIGHT_TESTS ON)
 
 ###################
 # monero-project
@@ -273,14 +272,11 @@ set(
     LIBRARY_SRC_FILES
     src/utils/gen_utils.cpp
     src/utils/monero_utils.cpp
-    src/utils/monero_light_client.cpp
-    src/utils/monero_light_model.cpp
     src/daemon/monero_daemon_model.cpp
     src/daemon/monero_daemon.cpp
     src/wallet/monero_wallet_model.cpp
     src/wallet/monero_wallet_keys.cpp
     src/wallet/monero_wallet_full.cpp
-    src/wallet/monero_wallet_light.cpp
 )
 
 if (BUILD_LIBRARY)
@@ -359,11 +355,8 @@ endif()
           DESTINATION include/daemon)
   INSTALL(FILES src/utils/gen_utils.h
           src/utils/monero_utils.h
-          src/utils/monero_light_client.h
-          src/utils/monero_light_model.h
           DESTINATION include/utils)
   INSTALL(FILES src/wallet/monero_wallet_full.h
-          src/wallet/monero_wallet_light.h
           src/wallet/monero_wallet.h
           src/wallet/monero_wallet_keys.h
           src/wallet/monero_wallet_model.h
@@ -587,79 +580,5 @@ if (BUILD_TESTS)
   )
   if (NOT WIN32)
     target_link_libraries(monero_tests dl)
-  endif()
-endif()
-
-
-
-########################
-# Build C++ light wallet tests
-########################
-
-if (BUILD_LIGHT_TESTS)
-  set(BUILD_LIGHT_TESTS test/monero_light_tests.cpp)
-  
-  add_executable(monero_light_tests ${LIBRARY_SRC_FILES} ${BUILD_LIGHT_TESTS})
-
-  target_include_directories(monero_light_tests PUBLIC
-      ${CMAKE_CURRENT_SOURCE_DIR}/include
-      src
-      "${MONERO_PROJECT}/contrib/epee/include"
-      "${MONERO_PROJECT}/external/"
-      "${MONERO_PROJECT}/external/easylogging++"
-      "${MONERO_PROJECT}/external/rapidjson/include"
-      "${MONERO_PROJECT_SRC}/"
-      "${MONERO_PROJECT_SRC}/wallet"
-      "${MONERO_PROJECT_SRC}/wallet/api"
-      "${MONERO_PROJECT_SRC}/hardforks"
-      "${MONERO_PROJECT_SRC}/crypto"
-      "${MONERO_PROJECT_SRC}/crypto/crypto_ops_builder/include/"
-      ${Protobuf_INCLUDE_DIR}
-      ${Boost_INCLUDE_DIR}
-      ${OPENSSL_INCLUDE_DIR}
-      external/libsodium/include/sodium
-      external/openssl-sdk/include
-      ${HIDAPI_INCLUDE_DIR}
-      ${UNBOUND_INCLUDE_DIR}
-  )
-  
-  target_link_libraries(monero_light_tests
-      wallet
-      rpc_base
-      net
-      lmdb
-      easylogging
-      cryptonote_core
-      cryptonote_protocol
-      cryptonote_basic
-      cryptonote_format_utils_basic
-      mnemonics
-      ringct
-      ringct_basic
-      common
-      blockchain_db
-      blocks
-      checkpoints
-      device
-      device_trezor
-      multisig
-      version
-      cncrypto
-      randomx
-      epee
-      hardforks
-      ${wallet_crypto}
-      
-      ${UNBOUND_LIBRARIES}
-      ${Boost_LIBRARIES}
-      ${Protobuf_LIBRARY}
-      ${LibUSB_LIBRARIES}
-      ${OPENSSL_LIBRARIES}
-      ${SODIUM_LIBRARY}
-      ${HIDAPI_LIBRARIES}
-      ${EXTRA_LIBRARIES}
-  )
-  if (NOT WIN32)
-    target_link_libraries(monero_light_tests dl)
   endif()
 endif()

--- a/src/wallet/monero_wallet_light.cpp
+++ b/src/wallet/monero_wallet_light.cpp
@@ -5039,7 +5039,7 @@ namespace monero {
     if (config.m_seed_offset != boost::none && !config.m_seed_offset.get().empty()) spend_key_sk = cryptonote::decrypt_key(spend_key_sk, config.m_seed_offset.get());
 
     // initialize wallet account
-    monero_wallet_light* wallet = new monero_wallet_light(http_client_factory);
+    monero_wallet_light* wallet = new monero_wallet_light(std::move(http_client_factory));
     wallet->m_account = cryptonote::account_base{};
     wallet->m_account.generate(spend_key_sk, true, false);
 
@@ -5121,7 +5121,7 @@ namespace monero {
     }
         
     // initialize wallet account
-    monero_wallet_light* wallet = new monero_wallet_light(http_client_factory);
+    monero_wallet_light* wallet = new monero_wallet_light(std::move(http_client_factory));
     if (has_spend_key && has_view_key) {
       wallet->m_account.create_from_keys(address_info.address, spend_key_sk, view_key_sk);
     } else if (has_spend_key) {
@@ -5163,7 +5163,7 @@ namespace monero {
     if (!monero_utils::is_valid_language(config_normalized.m_language.get())) throw std::runtime_error("Unknown language: " + config_normalized.m_language.get());
 
     // initialize random wallet account
-    monero_wallet_light* wallet = new monero_wallet_light(http_client_factory);
+    monero_wallet_light* wallet = new monero_wallet_light(std::move(http_client_factory));
     crypto::secret_key spend_key_sk = wallet->m_account.generate();
 
     // initialize remaining wallet


### PR DESCRIPTION
Fixed http_client_factory passed as an argument in function `monero_wallet_light::monero_wallet_light` to `std::move(http_client_factory)` and updated CMakeLists.txt to correct the order of inclusion of cncrypto library to avoid hmac_keccak_hash undefined reference.